### PR TITLE
Fix: Show current_bid instead of start_price when bid exists

### DIFF
--- a/auction-frontend/src/pages/ProductDetailPage.jsx
+++ b/auction-frontend/src/pages/ProductDetailPage.jsx
@@ -570,11 +570,11 @@ export default function ProductDetailPage() {
           {/* Pricing Container with Button & Bid Info */}
           <div className="product-pricing">
             <p className="pricing-label">
-              {(product.bid_count || 0) > 0 ? 'Current bid' : 'Starting price'}
+              {(product.current_bid || 0) > 0 ? 'Current bid' : 'Starting price'}
             </p>
             <p className="pricing-amount">
-              ${(product.bid_count || 0) > 0
-                ? (product.current_bid || 0).toFixed(2)
+              ${(product.current_bid || 0) > 0
+                ? product.current_bid.toFixed(2)
                 : product.start_price.toFixed(2)}
             </p>
 


### PR DESCRIPTION
Changed pricing display logic to check current_bid > 0 rather than bid_count > 0. This ensures the product page shows the correct price when current_bid is seeded, matching the BidModal display.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected pricing display on product detail pages to show current bid when available, with proper decimal formatting; falls back to starting price when no bids are present.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->